### PR TITLE
meta additions and readme correction

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 ## Notes
 - USA and PAL are considered complete and should not require updates
-- All Homebrew belongs in `meta_db_in`, yes even commercially discs
+- All Homebrew belongs in `meta_hb_in`, yes even commercial discs
 - All things that aren't homebrew and aren't retail belong in `meta_ex_in`. This includes things like prototypes, demo discs, propeller arena, etc...
 
 ## How to add metadata for a particular disc

--- a/meta_ex_in/6107994.txt
+++ b/meta_ex_in/6107994.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=1
+vmu_blocks=0
+accessories=VGA
+network=0
+genre=action
+description=An early prototype featuring one level. with Japanese dialogue accompanied by English Subtitles. This demo differs in several ways from the final version: Sonic wears his original shoes, different logo, billboards and sounds, looser controls and physics, and an instrumental version of "Escape from the City".
+padding0=0

--- a/meta_ex_in/T11001N.txt
+++ b/meta_ex_in/T11001N.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=1
+vmu_blocks=200
+accessories=0
+network=0
+genre=Action+Shooter+Survival+Adventure
+description=HALF-LIFE is a groundbreaking first-person shooter released in 1998 by Valve. Players control scientist Gordon Freeman as he fights to survice after a disastrous experiment unleashes alien creatures. Blending storytelling, action and puzzles seamlessly, it revolutionised the genre and became a landmark title in gaming history.
+padding0=0

--- a/meta_hb_in/BB0001.txt
+++ b/meta_hb_in/BB0001.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=2
+vmu_blocks=10
+accessories=VGA+KEY+ARC+JUMP
+network=0
+genre=shooter
+description=Xeno Crisis is an arena shooter in which up to two players enter a ravaged research colony to confront an alkien menace and get out alive! Run and gun your way through thousands of adversaries as you search for the source of the deadly alien outbreak.
+padding0=0

--- a/meta_hb_in/IND100506.txt
+++ b/meta_hb_in/IND100506.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=4
+vmu_blocks=2
+accessories=VGA+JUMP+KEY
+network=3
+genre=sports
+description=The automotive football game you never knew you needed... Forget the licensed cars and sponsored wraps, DRIVING STRIKERS is arcade perfect full 3D extreme sports action! Featuring online play. Take on players worldwide and rock out to a nostalgia-inducing soundtrack!
+padding0=0

--- a/meta_hb_in/T0000.txt
+++ b/meta_hb_in/T0000.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=4
+vmu_blocks=3
+accessories=VGA+JUMP+ARC
+network=0
+genre=racing+sports
+description=Rush Rush Rally Reloaded gives you retro style arcade racing at its very best. No sponsored cars, no realistic environments, just plain old fun! Featuring three single-player modes, eleven unique tracks, five race cars, and a soundtrack of certified bangers by acclaimed composer Ben Kurotoshiro!
+padding0=0

--- a/meta_hb_in/T0001.txt
+++ b/meta_hb_in/T0001.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=4
+vmu_blocks=0
+accessories=VGA+JUMP+KEY+MS+OLE+RACE+MIC+ARC+GUN+FISH+ASC
+network=0
+genre=0
+description=The 240p Test Suite for Dreamcast is a comprehensive homebrew tool for testing and calibrating video, audio and controller performance. It fetaures resolution and colour patterns, geometry and overscan checks, audio sync tests, controller input response tools and more.
+padding0=0

--- a/meta_jap_in/HDR0033.txt
+++ b/meta_jap_in/HDR0033.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=1
+vmu_blocks=2
+accessories=VGA+KEY+MOD
+network=0
+genre=0
+description=A series of bizarre murders occur one after another after a cursed contract is made. Numerous mysteries and shocking truths are entangled behind the scenes. The mystery grows with each passing minute, and the fear, madness, and despair deepen... Chapter 1: "Contract"
+padding0=0

--- a/meta_jap_in/HDR0034.txt
+++ b/meta_jap_in/HDR0034.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=1
+vmu_blocks=2
+accessories=VGA+KEY+MOD
+network=0
+genre=0
+description=A series of bizarre murders occur one after another after a cursed contract is made. Numerous mysteries and shocking truths are entangled behind the scenes. The mystery grows with each passing minute, and the fear, madness, and despair deepen... Chapter 2: "Birdcage"
+padding0=0

--- a/meta_jap_in/HDR0035.txt
+++ b/meta_jap_in/HDR0035.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=1
+vmu_blocks=2
+accessories=VGA+KEY+MOD
+network=0
+genre=0
+description=A series of bizarre murders occur one after another after a cursed contract is made. Numerous mysteries and shocking truths are entangled behind the scenes. The mystery grows with each passing minute, and the fear, madness, and despair deepen... Chapter 3: "Pitfall"
+padding0=0

--- a/meta_jap_in/HDR0036.txt
+++ b/meta_jap_in/HDR0036.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=1
+vmu_blocks=2
+accessories=VGA+KEY+MOD
+network=0
+genre=0
+description=A series of bizarre murders occur one after another after a cursed contract is made. Numerous mysteries and shocking truths are entangled behind the scenes. The mystery grows with each passing minute, and the fear, madness, and despair deepen... Chapter 4: "Encounter"
+padding0=0

--- a/meta_jap_in/HDR0037.txt
+++ b/meta_jap_in/HDR0037.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=1
+vmu_blocks=2
+accessories=VGA+KEY+MOD
+network=0
+genre=0
+description=A series of bizarre murders occur one after another after a cursed contract is made. Numerous mysteries and shocking truths are entangled behind the scenes. The mystery grows with each passing minute, and the fear, madness, and despair deepen... Chapter 5: "Atonement"
+padding0=0

--- a/meta_jap_in/HDR0038.txt
+++ b/meta_jap_in/HDR0038.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=1
+vmu_blocks=2
+accessories=VGA+KEY+MOD
+network=0
+genre=0
+description=A series of bizarre murders occur one after another after a cursed contract is made. Numerous mysteries and shocking truths are entangled behind the scenes. The mystery grows with each passing minute, and the fear, madness, and despair deepen... Chapter 6: "Terror"
+padding0=0

--- a/meta_jap_in/T23201M.txt
+++ b/meta_jap_in/T23201M.txt
@@ -1,0 +1,8 @@
+[ITEM]
+num_players=4
+vmu_blocks=5
+accessories=VGA+JUMP+MIC+GUN+MOD
+network=1
+genre=Lightgun+Shooter
+description=Death Crimson 2 is a rail shooter for the Sega Dreamcast, released in 1999 as a sequel to the infamous original. Players blast their way through bizarre enemies and surreal environments with lightgun or controller support.
+padding0=0


### PR DESCRIPTION
The following metadata added:
- Sonic Adventure 2: The Trial
- Half-Life (beta)
- Xeno Crisis
- Driving Strikers
- Rush Rush Rally Reloaded
- Death Crimson 2
- 240P Test Suite
- Grauen no Torikago (Birdcage of Horrors) -  x6 chapters

Readme correction: All Homebrew belongs in `meta_hb_in` (not `meta_db_in`)